### PR TITLE
Fix compilation

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -34,7 +34,7 @@ fn generate_bindings(out_dir: &str) {
 }
 
 fn compile_cmake() {
-	cmake::Config::new("randomx").build_target("").build();
+	cmake::Config::new("randomx").no_build_target(true).build();
 }
 
 fn exec_if_newer<F: Fn()>(inpath: &str, outpath: &str, build: F) {


### PR DESCRIPTION
Using cmake version 3.21.3 I got a problem compiling because it was passing `--target ""` to cmake invocation.

Passing an empty string to the flag makes the cmake to just print help message and exit with error status.

I believe that the reason to pass an empty string to target was to not set the target flag. So I changed to use `no_build_target(true)` instead.