### PR TITLE
Change variables from u64 to u32 to enable windows build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Randomx - Rust
+
+RandomX is a proof-of-work (PoW) algorithm that is optimized for general-purpose CPUs. RandomX uses random code execution (hence the name) together with several memory-hard techniques to minimize the efficiency advantage of specialized hardware.
+
+This is a rust build of the current Randomx algorithm
+
+## Build steps
+
+To build the project execute the following line in the terminal:
+
+```sh
+cargo build
+```
+
+## What was built
+
+The rust library of the RandomX algorithm

--- a/src/types.rs
+++ b/src/types.rs
@@ -177,10 +177,10 @@ impl RxState {
 		}
 
 		let mut threads = Vec::new();
-		let mut start: u64 = 0;
-		let count: u64 = unsafe { randomx_dataset_item_count() } as u64;
-		let perth: u64 = count / threads_count as u64;
-		let remainder: u64 = count % threads_count as u64;
+		let mut start: u32 = 0;
+		let count: u32 = unsafe { randomx_dataset_item_count() } as u32;
+		let perth: u32 = count / threads_count as u32;
+		let remainder: u32 = count % threads_count as u32;
 
 		for i in 0..threads_count {
 			let cache = Wrapper(NonNull::new(cache.cache).unwrap());


### PR DESCRIPTION
# Context

Our windows builds are failing with `The trait 'From<u64> ' is not implemented for 'u32'.

![image](https://user-images.githubusercontent.com/68653689/200656262-fb459d47-4df0-4435-956d-41d2f781b7ab.png)

Updating the code to use u32 makes the build run on windows again.

# Changes

Update u64 variables to u32 on `types.rs`.

# Tested on

- Ubuntu
- Windows
