### PR TITLE
Remove rust warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Randomx - Rust
+
+RandomX is a proof-of-work (PoW) algorithm that is optimized for general-purpose CPUs. RandomX uses random code execution (hence the name) together with several memory-hard techniques to minimize the efficiency advantage of specialized hardware.
+
+This is a rust build of the current Randomx algorithm
+
+## Build steps
+
+To build the project execute the following line in the terminal:
+
+```sh
+cargo build
+```
+
+## What was built
+
+The rust library of the RandomX algorithm

--- a/src/types.rs
+++ b/src/types.rs
@@ -140,7 +140,7 @@ impl RxState {
 		}
 
 		let flags = self.get_flags();
-		let mut cache_ptr = unsafe { randomx_alloc_cache(flags) };
+		let cache_ptr = unsafe { randomx_alloc_cache(flags) };
 
 		if cache_ptr.is_null() {
 			return Err("cache not allocated");
@@ -166,7 +166,7 @@ impl RxState {
 
 		//let mut dataset_ptr =
 		//	unsafe { randomx_alloc_dataset(randomx_flags_RANDOMX_FLAG_LARGE_PAGES) };
-		let mut dataset_ptr = unsafe { randomx_alloc_dataset(self.get_flags()) };
+		let dataset_ptr = unsafe { randomx_alloc_dataset(self.get_flags()) };
 
 		/*if dataset_ptr.is_null() {
 			dataset_ptr = unsafe { randomx_alloc_dataset(self.get_flags()) };
@@ -255,7 +255,7 @@ impl RxState {
 
 	pub fn update_vms(&mut self) {
 		for vm in &self.vms {
-			let mut vm_lock = vm.write().unwrap();
+			let vm_lock = vm.write().unwrap();
 			unsafe {
 				self.cache
 					.as_ref()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
 use bigint::uint::U256;
 use std::mem::transmute;
 
-pub fn from_u32_to_U256(v: &[u32; 8]) -> U256 {
+pub fn from_u32_to_u256(v: &[u32; 8]) -> U256 {
 	let vu64: [u64; 4] = unsafe { transmute(*v) };
 
 	U256(vu64)
@@ -13,7 +13,7 @@ mod test {
 	#[test]
 	fn test_u32_to_u256() {
 		let v = [1; 8];
-		let result = crate::utils::from_u32_to_U256(&v);
+		let result = crate::utils::from_u32_to_u256(&v);
 		let expected: U256 = (0..8).fold(U256::from(0), |acc, i| {
 			acc + U256::from(2).pow(U256::from(i * 32))
 		});
@@ -25,7 +25,7 @@ mod test {
 	fn test_u32_to_u256_simple() {
 		let mut v = [0; 8];
 		v[0] = 1;
-		let result = crate::utils::from_u32_to_U256(&v);
+		let result = crate::utils::from_u32_to_u256(&v);
 		let expected = U256::from(1);
 		assert_eq!(expected, result);
 	}


### PR DESCRIPTION
# Context

Remove the current warning when building the project.

The two main warning removed was:
- `warning: variable does not need to be mutable`
- `function from_u32_to_U256 should have a snake case name`

# Changes

- Update the snake case for the function from_u32_to_U256
- Remove mut from variables that don't need to be mutable